### PR TITLE
Add generated network schemas

### DIFF
--- a/tests/2016-03-30/Microsoft.Network.Connections.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.Connections.tests.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+	{
+      "name": "virtualNetworkGateways tests ",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/connections",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/connections",
+			"name": "[variables('connectionName1')]",
+			"location": "[parameters('existingVnetLocation')]",
+			"properties": {
+				"virtualNetworkGateway1": {
+					"id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('gatewayName1'))]"
+				},
+				"virtualNetworkGateway2": {
+					"id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('gatewayName2'))]"
+				},
+				"connectionType": "Vnet2Vnet",
+				"routingWeight": 3,
+				"sharedKey": "[parameters('sharedKey')]"
+			}
+		}
+    }
+  ]
+}

--- a/tests/2016-03-30/Microsoft.Network.ExpressRoute.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.ExpressRoute.tests.json
@@ -1,0 +1,70 @@
+{
+  "tests": [
+	{
+      "name": "expressRouteCircuits tests ",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/expressRouteCircuits",
+      "json": {
+			"apiVersion": "2016-03-30",
+            "type": "Microsoft.Network/expressRouteCircuits",
+            "name": "[parameters('circuitName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                "key1": "value1",
+                "key2": "value2"
+            },
+            "sku": {
+                "name": "[concat(parameters('sku_tier'),'_', parameters('sku_family'))]",
+                "tier": "[parameters('sku_tier')]",
+                "family": "[parameters('sku_family')]"
+            },
+            "properties": {
+                "serviceProviderProperties": {
+                    "serviceProviderName": "[parameters('serviceProviderName')]",
+                    "peeringLocation": "[parameters('peeringLocation')]",
+                    "bandwidthInMbps": "[parameters('bandwidthInMbps')]"
+                }
+            }
+		}
+	},
+	{
+      "name": "expressRouteCircuits tests with peering ",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/expressRouteCircuits",
+      "json": {
+			"apiVersion": "2016-03-30",            
+            "type": "Microsoft.Network/expressRouteCircuits",
+            "name": "[parameters('circuitName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                "key1": "value1",
+                "key2": "value2"
+            },
+            "sku": {
+                "name": "[concat(parameters('sku_tier'),'_', parameters('sku_family'))]",
+                "tier": "[parameters('sku_tier')]",
+                "family": "[parameters('sku_family')]"
+            },
+            "properties": {
+                "serviceProviderProperties": {
+                    "serviceProviderName": "[parameters('serviceProviderName')]",
+                    "peeringLocation": "[parameters('peeringLocation')]",
+                    "bandwidthInMbps": "[parameters('bandwidthInMbps')]"
+                },
+                "peerings": [
+                    {
+                        "name": "[parameters('peeringType')]",
+                        "properties": {
+                            "peeringType": "[parameters('peeringType')]",
+                            "sharedKey": "[parameters('sharedKey')]",
+                            "peerASN": "[parameters('peerASN')]",
+                            "primaryPeerAddressPrefix": "[parameters('primaryPeerAddressPrefix')]",
+                            "secondaryPeerAddressPrefix": "[parameters('secondaryPeerAddressPrefix')]",
+                            "vlanId": "[parameters('vlanId')]"
+                        }
+                    }
+                ]
+            }
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.LoadBalancers.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.LoadBalancers.tests.json
@@ -13,17 +13,17 @@
 				{
 					"name": "loadBalancerFrontEnd1",
 					"properties": {
-					"publicIPAddress": {
-						"id": "[variables('publicIPAddressID1')]"
-					}
+						"publicIPAddress": {
+							"id": "[variables('publicIPAddressID1')]"
+						}
 					}
 				},
 				{
 					"name": "loadBalancerFrontEnd2",
 					"properties": {
-					"publicIPAddress": {
-						"id": "[variables('publicIPAddressID2')]"
-					}
+						"publicIPAddress": {
+							"id": "[variables('publicIPAddressID2')]"
+						}
 					}
 				}
 				],
@@ -36,35 +36,35 @@
 				{
 					"name": "LBRuleForVIP1",
 					"properties": {
-					"frontendIPConfiguration": {
-						"id": "[variables('frontEndIPConfigID1')]"
-					},
-					"backendAddressPool": {
-						"id": "[variables('lbBackendPoolID')]"
-					},
-					"protocol": "tcp",
-					"frontendPort": 443,
-					"backendPort": 443,
-					"probe": {
-						"id": "[variables('lbProbeID')]"
-					}
+						"frontendIPConfiguration": {
+							"id": "[variables('frontEndIPConfigID1')]"
+						},
+						"backendAddressPool": {
+							"id": "[variables('lbBackendPoolID')]"
+						},
+						"protocol": "tcp",
+						"frontendPort": 443,
+						"backendPort": 443,
+						"probe": {
+							"id": "[variables('lbProbeID')]"
+						}
 					}
 				},
 				{
 					"name": "LBRuleForVIP2",
 					"properties": {
-					"frontendIPConfiguration": {
-						"id": "[variables('frontEndIPConfigID2')]"
-					},
-					"backendAddressPool": {
-						"id": "[variables('lbBackendPoolID')]"
-					},
-					"protocol": "tcp",
-					"frontendPort": 443,
-					"backendPort": 444,
-					"probe": {
-						"id": "[variables('lbProbeID')]"
-					}
+						"frontendIPConfiguration": {
+							"id": "[variables('frontEndIPConfigID2')]"
+						},
+						"backendAddressPool": {
+							"id": "[variables('lbBackendPoolID')]"
+						},
+						"protocol": "tcp",
+						"frontendPort": 443,
+						"backendPort": 444,
+						"probe": {
+							"id": "[variables('lbProbeID')]"
+						}
 					}
 				}
 				],

--- a/tests/2016-03-30/Microsoft.Network.LoadBalancers.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.LoadBalancers.tests.json
@@ -1,0 +1,87 @@
+{
+  "tests": [
+	{
+      "name": "loadbalancer tests ",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/loadBalancers",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"name": "[variables('loadBalancerName')]",
+			"type": "Microsoft.Network/loadBalancers",
+			"location": "[resourceGroup().location]",
+			"properties": {
+				"frontendIPConfigurations": [
+				{
+					"name": "loadBalancerFrontEnd1",
+					"properties": {
+					"publicIPAddress": {
+						"id": "[variables('publicIPAddressID1')]"
+					}
+					}
+				},
+				{
+					"name": "loadBalancerFrontEnd2",
+					"properties": {
+					"publicIPAddress": {
+						"id": "[variables('publicIPAddressID2')]"
+					}
+					}
+				}
+				],
+				"backendAddressPools": [
+				{
+					"name": "loadBalancerBackEnd"
+				}
+				],
+				"loadBalancingRules": [
+				{
+					"name": "LBRuleForVIP1",
+					"properties": {
+					"frontendIPConfiguration": {
+						"id": "[variables('frontEndIPConfigID1')]"
+					},
+					"backendAddressPool": {
+						"id": "[variables('lbBackendPoolID')]"
+					},
+					"protocol": "tcp",
+					"frontendPort": 443,
+					"backendPort": 443,
+					"probe": {
+						"id": "[variables('lbProbeID')]"
+					}
+					}
+				},
+				{
+					"name": "LBRuleForVIP2",
+					"properties": {
+					"frontendIPConfiguration": {
+						"id": "[variables('frontEndIPConfigID2')]"
+					},
+					"backendAddressPool": {
+						"id": "[variables('lbBackendPoolID')]"
+					},
+					"protocol": "tcp",
+					"frontendPort": 443,
+					"backendPort": 444,
+					"probe": {
+						"id": "[variables('lbProbeID')]"
+					}
+					}
+				}
+				],
+				"probes": [
+				{
+					"name": "tcpProbe",
+					"properties": {
+					"protocol": "tcp",
+					"port": 445,
+					"intervalInSeconds": 5,
+					"numberOfProbes": 2
+					}
+				}
+				]
+			}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "name": "nic tests - only subnet",
-      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
       "json": {
 			"apiVersion": "2016-03-30",
     		"type": "Microsoft.Network/networkInterfaces",
@@ -20,6 +20,100 @@
     				}
     			}
     			]
+    		}
+		}
+	},
+	{
+      "name": "nic tests - subnet and publicipAddress",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "json": {
+			"apiVersion": "2016-03-30",
+    		"type": "Microsoft.Network/networkInterfaces",
+    		"name": "[variables('nicName')]",
+    		"location": "[resourceGroup().location]",
+    		"properties": {
+    			"ipConfigurations": [
+    			{
+    				"name": "ipconfig1",
+    				"properties": {
+						"privateIPAllocationMethod": "Dynamic",
+						"subnet": {
+							"id": "[variables('subnetRef')]"
+						},
+						"publicipAddress": {
+							"id": "[variables('publicipref')]"
+						}
+    				}
+    			}
+    			]
+    		}
+		}
+	},
+	{
+      "name": "nic tests - subnet, publicipAddress and nsg",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "json": {
+			"apiVersion": "2016-03-30",
+    		"type": "Microsoft.Network/networkInterfaces",
+    		"name": "[variables('nicName')]",
+    		"location": "[resourceGroup().location]",
+    		"properties": {
+    			"ipConfigurations": [
+    			{
+    				"name": "ipconfig1",
+    				"properties": {
+						"privateIPAllocationMethod": "Dynamic",
+						"subnet": {
+							"id": "[variables('subnetRef')]"
+						},
+						"publicipAddress": {
+							"id": "[variables('subnetRef')]"
+						}
+    				}
+    			}
+    			],
+				"networkSecurityGroup" : {
+							"id": "[variables('nsgRef')]"
+				}
+    		}
+		}
+	},
+	{
+      "name": "nic tests - subnet, publicipAddress and Lb referece",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "json": {
+			"apiVersion": "2016-03-30",
+    		"type": "Microsoft.Network/networkInterfaces",
+    		"name": "[variables('nicName')]",
+    		"location": "[resourceGroup().location]",
+    		"properties": {
+    			"ipConfigurations": [
+    			{
+    				"name": "ipconfig1",
+    				"properties": {
+						"privateIPAllocationMethod": "Dynamic",
+						"subnet": {
+							"id": "[variables('subnetRef')]"
+						},
+						"publicipAddress": {
+							"id": "[variables('subnetRef')]"
+						},
+						"loadBalancerInboundNatRules" : [
+							{
+								"id": "[variables('ruleid')]"
+							}
+						],
+						"loadBalancerBackendAddressPools" : [
+							{
+								"id": "[variables('poolid')]"
+							}
+						]
+    				}
+    			}
+    			],
+				"networkSecurityGroup" : {
+							"id": "[variables('nsgRef')]"
+				}
     		}
 		}
 	}

--- a/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
@@ -1,0 +1,28 @@
+{
+  "tests": [
+    {
+      "name": "nic tests - only subnet",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "json": {
+			"apiVersion": "2016-03-30",
+    		"type": "Microsoft.Network/networkInterfaces",
+    		"name": "[variables('nicName')]",
+    		"location": "[resourceGroup().location]",
+    		"properties": {
+    			"ipConfigurations": [
+    			{
+    				"name": "ipconfig1",
+    				"properties": {
+						"privateIPAllocationMethod": "Dynamic",
+						"subnet": {
+							"id": "[variables('subnetRef')]"
+						}
+    				}
+    			}
+    			]
+    		}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.NetworkInterfaces.tests.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "name": "nic tests - only subnet",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
       "json": {
 			"apiVersion": "2016-03-30",
     		"type": "Microsoft.Network/networkInterfaces",
@@ -25,7 +25,7 @@
 	},
 	{
       "name": "nic tests - subnet and publicipAddress",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
       "json": {
 			"apiVersion": "2016-03-30",
     		"type": "Microsoft.Network/networkInterfaces",
@@ -51,7 +51,7 @@
 	},
 	{
       "name": "nic tests - subnet, publicipAddress and nsg",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
       "json": {
 			"apiVersion": "2016-03-30",
     		"type": "Microsoft.Network/networkInterfaces",
@@ -80,7 +80,7 @@
 	},
 	{
       "name": "nic tests - subnet, publicipAddress and Lb referece",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkInterfaces",
       "json": {
 			"apiVersion": "2016-03-30",
     		"type": "Microsoft.Network/networkInterfaces",

--- a/tests/2016-03-30/Microsoft.Network.NetworkSecurityGroup.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.NetworkSecurityGroup.tests.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+	{
+      "name": "networkSecurityGroup tests ",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkSecurityGroups",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/networkSecurityGroups",
+			"name": "[variables('networkSecurityGroupName')]",
+			"location": "[resourceGroup().location]",
+			"properties": {
+				"securityRules": [
+				{
+					"name": "first_rule",
+					"properties": {
+					"description": "This is the first rule",
+					"protocol": "Tcp",
+					"sourcePortRange": "23-45",
+					"destinationPortRange": "46-56",
+					"sourceAddressPrefix": "*",
+					"destinationAddressPrefix": "*",
+					"access": "Allow",
+					"priority": 123,
+					"direction": "Inbound"
+					}
+				}
+				]
+			}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.NetworkSecurityGroup.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.NetworkSecurityGroup.tests.json
@@ -2,7 +2,7 @@
   "tests": [
 	{
       "name": "networkSecurityGroup tests ",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/networkSecurityGroups",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/networkSecurityGroups",
       "json": {
 			"apiVersion": "2016-03-30",
 			"type": "Microsoft.Network/networkSecurityGroups",

--- a/tests/2016-03-30/Microsoft.Network.PublicIpAddress.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.PublicIpAddress.tests.json
@@ -1,0 +1,40 @@
+{
+  "tests": [
+    {
+      "name": "Publicip tests - minimal resource",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/publicIPAddresses",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/publicIPAddresses",
+			"name": "[variables('publicIPAddressName')]",
+			"location": "[resourceGroup().location]",
+			"properties": {
+				"publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
+				"dnsSettings": {
+					"domainNameLabel": "[parameters('dnsLabelPrefix')]"
+				}
+			}
+		}
+	},
+	{
+      "name": "Publicip tests - fqdn and idletimeout",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/publicIPAddresses",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/publicIPAddresses",
+			"name": "[variables('publicIPAddressName')]",
+			"location": "[resourceGroup().location]",
+			"properties": {
+				"publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
+				"idleTimeoutInMinutes" : 5,
+				"publicIPAddressVersion": "IPv4",
+				"dnsSettings": {
+					"domainNameLabel": "[parameters('dnsLabelPrefix')]",
+					"reverseFqdn" : "[parameters('dnsLabelPrefix')]"
+				}
+			}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.RouteTable.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.RouteTable.tests.json
@@ -2,7 +2,7 @@
   "tests": [
 	{
       "name": "networkSecurityGroup tests ",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/routeTables",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/routeTables",
       "json": {
 			"type": "Microsoft.Network/routeTables",
 			"name": "[variables('routeTableName')]",

--- a/tests/2016-03-30/Microsoft.Network.RouteTable.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.RouteTable.tests.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+	{
+      "name": "networkSecurityGroup tests ",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/routeTables",
+      "json": {
+			"type": "Microsoft.Network/routeTables",
+			"name": "[variables('routeTableName')]",
+			"apiVersion": "2016-03-30",
+			"location": "[parameters('location')]",
+			"properties": {
+				"routes": [{
+					"name": "VirtualApplianceRouteToSubnet3",
+					"properties": {
+						"addressPrefix": "[variables('subnet3Prefix')]",
+						"nextHopType": "VirtualAppliance",
+						"nextHopIpAddress": "[variables('NvmPrivateIPAddress')]"
+					}
+				}]
+			}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.VirtualNetwork.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.VirtualNetwork.tests.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "name": "virtal network tests - minimal resource",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
       "json": {
 			"apiVersion": "2016-03-30",
 			"type": "Microsoft.Network/virtualNetworks",
@@ -27,7 +27,7 @@
 	},
 	{
       "name": "virtal network tests - routetable and nsg resource",
-      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
       "json": {
 			"apiVersion": "2016-03-30",
 			"type": "Microsoft.Network/virtualNetworks",

--- a/tests/2016-03-30/Microsoft.Network.VirtualNetwork.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.VirtualNetwork.tests.json
@@ -1,0 +1,61 @@
+{
+  "tests": [
+    {
+      "name": "virtal network tests - minimal resource",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/virtualNetworks",
+			"name": "[variables('virtualNetworkName')]",
+			"location": "[resourceGroup().location]",
+			"properties": {
+					"addressSpace": {
+					"addressPrefixes": [
+						"[parameters('vnetAddressPrefix')]"
+					]
+				},
+				"subnets": [
+					{
+						"name": "[variables('subnetName')]",
+						"properties": {
+							"addressPrefix": "[parameters('subnetPrefix')]"
+						}
+					}
+				]
+			}
+		}
+	},
+	{
+      "name": "virtal network tests - routetable and nsg resource",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Network.json#/resourceDefinitions/virtualNetworks",
+      "json": {
+			"apiVersion": "2016-03-30",
+			"type": "Microsoft.Network/virtualNetworks",
+			"name": "[variables('virtualNetworkName')]",
+			"location": "[resourceGroup().location]",
+			"properties": {
+					"addressSpace": {
+					"addressPrefixes": [
+						"[parameters('vnetAddressPrefix')]"
+					]
+				},
+				"subnets": [
+					{
+						"name": "[variables('subnetName')]",
+						"properties": {
+							"addressPrefix": "[parameters('subnetPrefix')]",
+							"networkSecurityGroup" : {
+								"id": "[variables('nsgRef')]"
+							},
+							"routeTable" : {
+								"id": "[variables('rtRef')]"
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+  ]
+}
+

--- a/tests/2016-03-30/Microsoft.Network.VirtualNetworkGateway.tests.json
+++ b/tests/2016-03-30/Microsoft.Network.VirtualNetworkGateway.tests.json
@@ -1,0 +1,94 @@
+{
+  "tests": [
+	{
+      "name": "virtualNetworkGateways tests ",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/virtualnetworkgateways",
+      "json": {
+			"apiVersion": "2016-03-30",
+            "type": "Microsoft.Network/virtualNetworkGateways",
+            "name": "[parameters('gatewayName1')]",
+            "location": "[parameters('location1')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('gatewaySubnetRef1')]"
+                            },
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName1'))]"
+                            }
+                        },
+                        "name": "vnetGatewayConfig1"
+                    }
+                ],
+                "gatewayType": "Vpn",
+                "vpnType": "RouteBased",
+                "enableBgp": "false"
+            }
+		}
+	},
+	{
+      "name": "virtualNetworkGateways tests - point to site",
+      "definition": "http://schema.management.azure.com/schemas/2016-03-30/Microsoft.Network.json#/resourceDefinitions/virtualnetworkgateways",
+      "json": {
+			"apiVersion": "2016-03-30",
+            "type":"Microsoft.Network/virtualNetworkGateways",
+			"name":"[parameters('gatewayName')]",
+			"location":"[variables('location')]",
+			"dependsOn":[  
+				"[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+				"[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+			],
+			"properties":{  
+				"ipConfigurations":[  
+				{  
+					"properties":{  
+						"privateIPAllocationMethod":"Dynamic",
+						"subnet":{  
+							"id":"[variables('gatewaySubnetRef')]"
+						},
+						"publicIPAddress":{  
+							"id":"[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+						}
+					},
+					"name":"vnetGatewayConfig"
+				}
+				],
+				"sku": {
+					"name": "[parameters('gatewaySku')]",
+					"tier": "[parameters('gatewaySku')]"
+				},            
+				"gatewayType":"Vpn",
+				"vpnType":"RouteBased",
+				"enableBgp":"false",
+				"vpnClientConfiguration":{  
+				"vpnClientAddressPool":{  
+					"addressPrefixes":[  
+						"[parameters('vpnClientAddressPoolPrefix')]"
+					]
+				},
+				"vpnClientRootCertificates":[  
+					{  
+						"name": "[parameters('clientRootCertName')]",
+						"properties":{
+							"PublicCertData": "[parameters('clientRootCertData')]"
+						}
+					}
+				],
+				"vpnClientRevokedCertificates":[  
+					{  
+						"name": "[parameters('revokedCertName')]",
+						"properties":{  
+							"Thumbprint": "[parameters('revokedCertThumbprint')]"
+						}
+					}
+				]
+				}
+			}
+		}	
+	}
+  ]
+}
+


### PR DESCRIPTION
Added network tests.

There seems to be something wrong with subnet and pubicip reference tests. There are 10 tests which fail, especially nic tests. these tests succeeded in the existing schema, not sure what is wrong with the generated schema. Other than these failures, it looks good to me. (there is one test which fails with the same error in the existing schema - "virtal network tests - routetable and nsg resource")

If we can figure out these test failures, we are good to checkin the schema

  Running test "nic tests - only subnet"
Error: tv4ValidationResult should not have had any empty missing schemas: [
  "",
  ""
]
Expected: "not empty"
Actual:   ""
    at Fail (F:\git\Azure\azure-resource-manager-schemas\tools\assert.js:10:9)
    at Object.NotEmpty (F:\git\Azure\azure-resource-manager-schemas\tools\assert.js:51:5)
    at convertTv4ValidationResult (F:\git\Azure\azure-resource-manager-schemas\tools\validateJSON.js
:108:12)
    at Object.validate (F:\git\Azure\azure-resource-manager-schemas\tools\validateJSON.js:93:18)
    at F:\git\Azure\azure-resource-manager-schemas\tools\runSchemaTests.js:50:30
    at Object.run (F:\git\Azure\azure-resource-manager-schemas\tools\test.js:9:5)
    at Object.<anonymous> (F:\git\Azure\azure-resource-manager-schemas\tools\runSchemaTests.js:32:10
)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
  Running test "nic tests - subnet and publicipAddress"
Error: tv4ValidationResult should not have had any empty missing schemas: [
  "",
  ""
]
Expected: "not empty"
Actual:   ""
    at Fail (F:\git\Azure\azure-resource-manager-schemas\tools\assert.js:10:9)
    at Object.NotEmpty (F:\git\Azure\azure-resource-manager-schemas\tools\assert.js:51:5)
    at convertTv4ValidationResult (F:\git\Azure\azure-resource-manager-schemas\tools\validateJSON.js
:108:12)
    at Object.validate (F:\git\Azure\azure-resource-manager-schemas\tools\validateJSON.js:93:18)
    at F:\git\Azure\azure-resource-manager-schemas\tools\runSchemaTests.js:50:30
    at Object.run (F:\git\Azure\azure-resource-manager-schemas\tools\test.js:9:5)
    at Object.<anonymous> (F:\git\Azure\azure-resource-manager-schemas\tools\runSchemaTests.js:32:10
)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)